### PR TITLE
feat: add vtom-helm to org profile

### DIFF
--- a/profile/README.fr.md
+++ b/profile/README.fr.md
@@ -12,6 +12,9 @@ Nous développons des **connecteurs open source** pour **Visual TOM** (VTOM), un
 
 Découvrez notre collection complète de connecteurs VTOM :
 
+### ☸️ Kubernetes & Déploiement
+- **[vtom-helm](https://github.com/AbsyssLab/vtom-helm)** - Chart Helm pour déployer Visual TOM sur Kubernetes (AKS, GKE, EKS, on-premise)
+
 ### ☁️ Cloud & Automation
 - **[vtom-azure-data-factory](https://github.com/AbsyssLab/vtom-azure-data-factory)** - Orchestration des pipelines Azure Data Factory
 - **[vtom-azure-logic-app](https://github.com/AbsyssLab/vtom-azure-logic-app)** - Déclenchement de workflows Azure Logic Apps

--- a/profile/README.md
+++ b/profile/README.md
@@ -12,6 +12,9 @@ We develop **open source connectors** for **Visual TOM** (VTOM), a leading IT wo
 
 Discover our complete collection of VTOM connectors:
 
+### ☸️ Kubernetes & Deployment
+- **[vtom-helm](https://github.com/AbsyssLab/vtom-helm)** - Helm chart to deploy Visual TOM on Kubernetes (AKS, GKE, EKS, on-premise)
+
 ### ☁️ Cloud & Automation
 - **[vtom-azure-data-factory](https://github.com/AbsyssLab/vtom-azure-data-factory)** - Azure Data Factory pipeline orchestration
 - **[vtom-azure-logic-app](https://github.com/AbsyssLab/vtom-azure-logic-app)** - Azure Logic Apps workflow triggering


### PR DESCRIPTION
## Summary
Adds the newly published [`AbsyssLab/vtom-helm`](https://github.com/AbsyssLab/vtom-helm) chart to the org profile.

Creates a new category **☸️ Kubernetes & Deployment** in both EN (`profile/README.md`) and FR (`profile/README.fr.md`) versions, placed before the connector categories — `vtom-helm` deploys Visual TOM itself, not a third-party integration.

## Context
- Repo: https://github.com/AbsyssLab/vtom-helm
- First release: `v0.1.0` (chart name: `visual-tom`)
- Distribution: `oci://ghcr.io/absysslab/visual-tom` (anonymous pull)
- License: Apache 2.0
- Targets: Azure AKS (prod), GCP GKE Autopilot (validated), AWS EKS (implemented), on-premise / Minikube

## Test plan
- [ ] Verify category renders correctly on https://github.com/AbsyssLab once merged
- [ ] Verify both EN and FR versions are consistent